### PR TITLE
Update instance url for Vanilla Minigames instance

### DIFF
--- a/instances/instances.json
+++ b/instances/instances.json
@@ -19,9 +19,9 @@
 	},
 	{
 		"name": "Vanilla Minigames",
-		"url": "https://vanillaminigames.net",
+		"url": "https://chat.booky.dev",
 		"description": "Just another Spacebar instance which is run by a vanilla-only Minecraft server.",
-		"image": "https://vanillaminigames.net/img/icon.png",
+		"image": "https://booky.dev/vm_favicon.png",
 		"display": true,
 		"verified": false,
 		"country": "de",


### PR DESCRIPTION
`https://spacebar.vanillaminigames.net` currently doesn't work and I don't know when it will work again. `https://chat.booky.dev` is the same spacebar instance, but with a working domain.